### PR TITLE
Integrate Git workflow helpers into NeuroCLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The core architectural principle of NeuroCLI is a strict separation of concerns 
 
 ### Prerequisites
 * Python 3.10+
+* Git 2.30+ available on your `PATH` for the Git-assisted workflow
+* (Optional) An `$EDITOR` environment variable if you want to open files from NeuroCLI
 * An OpenAI API key stored in a project-level `.env` file:
 
   ```bash
@@ -30,3 +32,19 @@ pip install -e .
 ```bash
 neurocli
 ```
+
+## Git-Enabled Workflow
+
+NeuroCLI can now surface Git information and apply AI-generated patches directly through `git apply`.
+
+1. Select a file in the `file_path` input (or via **Browse...**) before submitting a prompt.
+2. After the diff is generated, use **Apply Changes** to choose between:
+   * **Apply (Working Tree)** – applies the diff with `git apply`. When the selected file is outside a Git repository, NeuroCLI falls back to writing the new content directly to disk so you never lose the proposal.
+   * **Apply & Stage** – applies the diff and stages the file with `git add`.
+3. Use **Stage Diff** at any time to stage the current file, and **Open in $EDITOR** to jump into your configured editor without leaving the TUI.
+
+### Safeguards and Status Feedback
+
+* The Git status panel automatically targets the selected file and displays the current branch and `git status --short` output.
+* When no repository is detected, staging actions are disabled, and the Apply workflow transparently writes to disk without invoking Git.
+* Errors and successes from Git helpers appear inline in the AI response panel so you can confirm each step.

--- a/neurocli_app/main.py
+++ b/neurocli_app/main.py
@@ -1,26 +1,34 @@
+from __future__ import annotations
+
+import difflib
+from pathlib import Path
+from typing import Optional
+
 from textual.app import App, ComposeResult
 from textual.containers import VerticalScroll, Horizontal, Container
 from textual.widgets import Header, Footer, Input, Button, Markdown, LoadingIndicator, Static
 from textual.worker import Worker, WorkerState
 from textual_fspicker import FileOpen
+
 from neurocli_app.theme import arctic_theme, modern_theme
 from neurocli_app.art import BACKGROUND_ART
-
-
 from neurocli_core.engine import get_ai_response
 from neurocli_core.diff_generator import generate_diff
 from neurocli_core.code_formatter import format_python_code
+from neurocli_core import git_tools
+from neurocli_core.git_tools import GitError, GitRepositoryNotFound
 
 
 class NeuroApp(App):
     """The main application for NeuroCLI."""
+
     BINDINGS = [("ctrl+q", "quit", "Quit")]
-   # DEFAULT_THEME = modern_theme
-    #CSS_PATH = "modern.css"
-     # --- ADD THIS CSS TO STYLE THE LAYOUT ---
     CSS_PATH = "main.css"
 
     _proposed_content: str = ""
+    _git_patch: str = ""
+    _last_diff_markdown: str = ""
+    _selected_file_path: Optional[str] = None
 
     def compose(self) -> ComposeResult:
         """Create child widgets for the app."""
@@ -34,105 +42,239 @@ class NeuroApp(App):
             yield Input(placeholder="Enter your prompt...", id="prompt_input")
             yield Markdown("AI response will appear here...", id="response_display")
             yield Button("Apply Changes", id="apply_button")
+            with Container(id="git_container"):
+                yield Markdown("Git status will appear here once a file is selected.", id="git_status_display")
+                with Horizontal(id="git_buttons"):
+                    yield Button("Stage Diff", id="stage_diff")
+                    yield Button("Open in $EDITOR", id="open_editor")
             yield LoadingIndicator(id="loading_indicator")
-            
-            # --- CORRECTED SECTION ---
-            # The Container now properly wraps the dialog widgets.
-             # MODIFIED: Removed the extra Horizontal container around the buttons
             with Container(id="button_container"):
-                yield Static("Apply these changes?", id="dialog_text")
-                yield Button("Yes", id="yes", variant="success")
-                yield Button("No", id="no", variant="error")
-                
-        yield Footer()
+                yield Static("How should NeuroCLI apply this patch?", id="dialog_text")
+                yield Button("Apply & Stage", id="apply_stage", variant="success")
+                yield Button("Apply (Working Tree)", id="apply_worktree", variant="primary")
+                yield Button("Cancel", id="cancel_apply", variant="error")
 
+        yield Footer()
 
     def on_mount(self) -> None:
         """Called when the app is mounted."""
-        self.register_theme(arctic_theme) 
-        self.register_theme(modern_theme)  
+        self.register_theme(arctic_theme)
+        self.register_theme(modern_theme)
 
         # Set the app's theme
-        self.theme = "arctic" 
-        self.theme = "modern_dark_neon" 
+        self.theme = "arctic"
+        self.theme = "modern_dark_neon"
         self.query_one("#loading_indicator").styles.display = "none"
         self.query_one("#apply_button").styles.display = "none"
         self.query_one("#button_container").styles.display = "none"
+        self._set_git_buttons_enabled(stage=False, open_editor=False)
+
+    def _set_git_buttons_enabled(self, *, stage: bool, open_editor: bool) -> None:
+        self.query_one("#stage_diff", Button).disabled = not stage
+        self.query_one("#open_editor", Button).disabled = not open_editor
+
+    def refresh_git_status(self) -> None:
+        """Trigger a background update of the Git status widget."""
+        git_status_display = self.query_one("#git_status_display", Markdown)
+        file_path = self._selected_file_path
+        if not file_path:
+            git_status_display.update("Select a file to view Git status.")
+            self._set_git_buttons_enabled(stage=False, open_editor=False)
+            return
+
+        try:
+            git_tools.detect_git_root(file_path)
+        except GitRepositoryNotFound as exc:
+            git_status_display.update(f"### Git Status\n{exc}")
+            self._set_git_buttons_enabled(stage=False, open_editor=True)
+            return
+
+        git_status_display.update("Fetching Git status...")
+
+        def status_worker() -> str:
+            try:
+                return git_tools.get_status_for_path(file_path)
+            except GitRepositoryNotFound as exc:
+                return f"### Git Status\n{exc}"
+            except GitError as exc:
+                return f"### Git Status\nError: {exc}"
+
+        self._set_git_buttons_enabled(stage=True, open_editor=True)
+        self.run_worker(status_worker, thread=True, name="git-status")
+
+    def _build_patch(self, original_content: str, new_content: str) -> str:
+        if not self._selected_file_path:
+            return ""
+
+        path_obj = Path(self._selected_file_path).resolve()
+        relative_path = path_obj
+        try:
+            repo_root = git_tools.detect_git_root(path_obj)
+            relative_path = path_obj.relative_to(repo_root)
+        except GitRepositoryNotFound:
+            pass
+
+        diff = difflib.unified_diff(
+            original_content.splitlines(keepends=True),
+            new_content.splitlines(keepends=True),
+            fromfile=f"a/{relative_path.as_posix()}",
+            tofile=f"b/{relative_path.as_posix()}",
+        )
+        return "".join(diff)
+
+    def _apply_patch_worker(self, stage: bool) -> str:
+        if not self._selected_file_path:
+            raise GitError("No file selected for applying the patch.")
+        if not self._git_patch.strip():
+            raise GitError("There is no patch to apply.")
+
+        path_obj = Path(self._selected_file_path).resolve()
+
+        try:
+            message = git_tools.apply_patch(self._git_patch, start_path=path_obj)
+        except GitRepositoryNotFound:
+            if stage:
+                raise GitError("Staging requires a Git repository.")
+            if not self._proposed_content:
+                raise GitError("No generated content is available to write.")
+            path_obj.write_text(self._proposed_content, encoding="utf-8")
+            return f"Wrote changes directly to {path_obj} (no Git repository detected)."
+        if stage:
+            staged = git_tools.stage_paths([path_obj])
+            message = f"{message}\n{staged}"
+        return message
+
+    def _stage_worker(self) -> str:
+        if not self._selected_file_path:
+            raise GitError("No file selected to stage.")
+        path_obj = Path(self._selected_file_path).resolve()
+        try:
+            return git_tools.stage_paths([path_obj])
+        except GitRepositoryNotFound as exc:
+            raise GitError(str(exc))
+
+    def _open_editor_worker(self) -> str:
+        if not self._selected_file_path:
+            raise GitError("No file selected to open.")
+        return git_tools.open_in_editor(self._selected_file_path)
+
+    def _update_response_with_message(self, message: str) -> None:
+        markdown_display = self.query_one("#response_display", Markdown)
+        if self._last_diff_markdown:
+            markdown_display.update(f"{self._last_diff_markdown}\n\n> {message}")
+        else:
+            markdown_display.update(message)
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
-        """Handle the press of the 'Browse...' button."""
+        """Handle button presses in the UI."""
         if event.button.id == "browse_button":
             self.push_screen(FileOpen(), self.on_file_open_selected)
         elif event.button.id == "apply_button":
             self.query_one("#button_container").styles.display = "block"
-
-        # ---- When confirmed Yes on dialog box ---- #
-        elif event.button.id == "yes":
-            file_path = self.query_one("#file_path_input", Input).value
-            if file_path and self._proposed_content:
-                try:
-                    with open(file_path, "w", encoding="utf-8") as f:
-                        f.write(self._proposed_content)
-                    self.query_one("#response_display").update(f"Changes applied to {file_path} successfully.")
-                    self._proposed_content = ""
-                    self.query_one("#apply_button").styles.display = "none"
-                except Exception as e:
-                    self.query_one("#response_display").update(f"Error applying changes: {e}")
-        
-        # ---- When confirmed No on dialog box ---- #
-        elif event.button.id == "no":
-            # Just hide the dialog
+        elif event.button.id == "apply_worktree":
             self.query_one("#button_container").styles.display = "none"
-
+            self.run_worker(lambda: self._apply_patch_worker(stage=False), thread=True, name="git-apply")
+        elif event.button.id == "apply_stage":
+            self.query_one("#button_container").styles.display = "none"
+            self.run_worker(lambda: self._apply_patch_worker(stage=True), thread=True, name="git-apply-stage")
+        elif event.button.id == "cancel_apply":
+            self.query_one("#button_container").styles.display = "none"
+        elif event.button.id == "stage_diff":
+            self.run_worker(self._stage_worker, thread=True, name="git-stage")
+        elif event.button.id == "open_editor":
+            self.run_worker(self._open_editor_worker, thread=True, name="open-editor")
 
     def on_file_open_selected(self, path: str) -> None:
         """Callback for when a file is selected from the dialog."""
         if path:
             self.query_one("#file_path_input", Input).value = str(path)
+            self._selected_file_path = str(path)
+            self.refresh_git_status()
 
     async def on_input_submitted(self, message: Input.Submitted) -> None:
         """Handle the submission of the prompt input."""
         if message.input.id == "prompt_input":
             prompt = message.value
             file_path_input = self.query_one("#file_path_input", Input)
-            file_path = file_path_input.value
+            file_path = file_path_input.value or None
+            self._selected_file_path = file_path
 
-            # --- 4. HIDE THE BACKGROUND IMAGE ---
             self.query_one("#background_image").styles.display = "none"
-
             self.query_one("#loading_indicator").styles.display = "block"
-            self.run_worker(lambda: get_ai_response(prompt, file_path), thread=True)
+            self.run_worker(lambda: get_ai_response(prompt, file_path), thread=True, name="ai-request")
             message.input.value = ""
+            if file_path:
+                self.refresh_git_status()
+            else:
+                self.query_one("#git_status_display", Markdown).update("Select a file to view Git status.")
+                self._set_git_buttons_enabled(stage=False, open_editor=False)
 
     def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
         """Called when the worker state changes."""
-        loading_indicator = self.query_one("#loading_indicator")
         markdown_display = self.query_one("#response_display", Markdown)
 
-        if event.state == WorkerState.SUCCESS:
-            original_content, new_content = event.worker.result
-            if original_content:
-                formatted_content = format_python_code(new_content)
-                diff = generate_diff(original_content, formatted_content)
-                markdown_display.update(diff)
-                self._proposed_content = formatted_content
-                self.query_one("#apply_button").styles.display = "block"
-            else:
-                markdown_display.update(new_content)
+        if event.worker.name == "ai-request":
+            loading_indicator = self.query_one("#loading_indicator")
+            if event.state == WorkerState.SUCCESS:
+                original_content, new_content = event.worker.result
+                if original_content:
+                    formatted_content = format_python_code(new_content)
+                    diff = generate_diff(original_content, formatted_content)
+                    self._last_diff_markdown = diff
+                    self._proposed_content = formatted_content
+                    self._git_patch = self._build_patch(original_content, formatted_content)
+                    markdown_display.update(diff)
+                    self.query_one("#apply_button").styles.display = "block" if self._git_patch else "none"
+                else:
+                    markdown_display.update(new_content)
+                    self._last_diff_markdown = new_content
+                    self._proposed_content = ""
+                    self._git_patch = ""
+                    self.query_one("#apply_button").styles.display = "none"
+            elif event.state == WorkerState.ERROR:
+                error_message = f"### Worker Error\n\n```\n{event.worker.error}\n```"
+                markdown_display.update(error_message)
+                self._last_diff_markdown = error_message
+                self._proposed_content = ""
+                self._git_patch = ""
                 self.query_one("#apply_button").styles.display = "none"
 
+            self.query_one("#background_image").styles.display = "block"
+            loading_indicator.styles.display = "none"
+            return
+
+        if event.worker.name == "git-status":
+            if event.state == WorkerState.SUCCESS:
+                self.query_one("#git_status_display", Markdown).update(event.worker.result)
+            elif event.state == WorkerState.ERROR:
+                self.query_one("#git_status_display", Markdown).update(
+                    f"### Git Status\nError: {event.worker.error}"
+                )
+            return
+
+        if event.state == WorkerState.SUCCESS:
+            message = event.worker.result
+            self._update_response_with_message(message)
+            if event.worker.name in {"git-apply", "git-apply-stage"}:
+                self._proposed_content = ""
+                self._git_patch = ""
+                self.query_one("#apply_button").styles.display = "none"
+                if self._selected_file_path:
+                    self.refresh_git_status()
+            elif event.worker.name == "git-stage" and self._selected_file_path:
+                self.refresh_git_status()
         elif event.state == WorkerState.ERROR:
-            # Display the error in the Markdown widget
-            error_message = f"### Worker Error\n\n```\n{event.worker.error}\n```"
-            markdown_display.update(error_message)
-            
-        # --- 4. SHOW THE BACKGROUND IMAGE AGAIN ---
-        self.query_one("#background_image").styles.display = "block"
-        loading_indicator.styles.display = "none"
+            self._update_response_with_message(f"Error: {event.worker.error}")
+
+    def on_unmount(self) -> None:
+        """Ensure background workers stop on exit."""
+        self.workers.cancel_all()
+
 
 def main():
     app = NeuroApp()
     app.run()
+
 
 if __name__ == "__main__":
     main()

--- a/neurocli_core/git_tools.py
+++ b/neurocli_core/git_tools.py
@@ -1,0 +1,172 @@
+"""Git integration utilities for NeuroCLI.
+
+This module centralizes subprocess-based Git operations so they can be
+reused safely by the Textual front-end.  Each helper automatically resolves
+the repository root for the provided path and raises descriptive errors when
+Git is unavailable.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Iterable, Optional
+
+__all__ = [
+    "GitError",
+    "GitRepositoryNotFound",
+    "detect_git_root",
+    "get_status_for_path",
+    "apply_patch",
+    "stage_paths",
+    "open_in_editor",
+]
+
+
+class GitError(RuntimeError):
+    """Base exception for Git-related failures."""
+
+
+class GitRepositoryNotFound(GitError):
+    """Raised when attempting to operate outside of a Git repository."""
+
+    def __init__(self, start_path: Path) -> None:
+        super().__init__(f"No Git repository found for {start_path}.")
+        self.start_path = start_path
+
+
+def _run_git_command(args: list[str], cwd: Path, **kwargs) -> subprocess.CompletedProcess[str]:
+    """Execute a Git command, returning the completed process."""
+
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        text=True,
+        check=True,
+        capture_output=True,
+        **kwargs,
+    )
+
+
+def detect_git_root(start_path: Optional[os.PathLike[str] | str] = None) -> Path:
+    """Locate the Git repository root starting from ``start_path``.
+
+    Args:
+        start_path: A file or directory path used as the starting point.
+            Defaults to the NeuroCLI project directory.
+
+    Raises:
+        GitRepositoryNotFound: If no repository can be found.
+
+    Returns:
+        The resolved path to the repository root.
+    """
+
+    if start_path is None:
+        start_path = Path(__file__).resolve().parent.parent
+    start_path = Path(start_path).resolve()
+
+    search_path = start_path if start_path.is_dir() else start_path.parent
+
+    try:
+        result = _run_git_command(["rev-parse", "--show-toplevel"], cwd=search_path)
+    except subprocess.CalledProcessError as exc:
+        raise GitRepositoryNotFound(search_path) from exc
+
+    return Path(result.stdout.strip())
+
+
+def get_status_for_path(target_path: Optional[os.PathLike[str] | str] = None) -> str:
+    """Return the Git status summary for ``target_path``.
+
+    Args:
+        target_path: Optional path whose status should be inspected. When
+            provided, the output mirrors ``git status --short -- <path>``.
+
+    Returns:
+        A formatted status string suitable for display.
+    """
+
+    repo_root = detect_git_root(target_path)
+
+    status_args = ["status", "--short"]
+    branch_result = _run_git_command(["branch", "--show-current"], cwd=repo_root)
+    branch_name = branch_result.stdout.strip() or "(detached HEAD)"
+
+    if target_path:
+        relative_path = Path(target_path).resolve().relative_to(repo_root)
+        status_args.extend(["--", str(relative_path)])
+
+    status_result = _run_git_command(status_args, cwd=repo_root)
+    status_output = status_result.stdout.strip() or "Clean"
+
+    header = f"### Git Status — {branch_name}\n"
+    if target_path:
+        header += f"`{relative_path}`\n\n"
+
+    return f"{header}```\n{status_output}\n```"
+
+
+def apply_patch(patch: str, *, start_path: Optional[os.PathLike[str] | str] = None) -> str:
+    """Apply a unified diff to the working tree via ``git apply``.
+
+    Args:
+        patch: Unified diff text.
+        start_path: Path used to resolve the repository root.
+
+    Returns:
+        A confirmation message describing the outcome.
+    """
+
+    if not patch.strip():
+        raise GitError("No patch content provided.")
+
+    repo_root = detect_git_root(start_path)
+
+    try:
+        _run_git_command(["apply", "--whitespace=nowarn"], cwd=repo_root, input=patch)
+    except subprocess.CalledProcessError as exc:
+        raise GitError(exc.stderr.strip() or "Failed to apply patch.") from exc
+
+    return "Patch applied to working tree."
+
+
+def stage_paths(paths: Iterable[os.PathLike[str] | str]) -> str:
+    """Stage the provided paths via ``git add``.
+
+    Args:
+        paths: Iterable of file paths to stage.
+
+    Returns:
+        A confirmation message describing the staged files.
+    """
+
+    paths = list(paths)
+    if not paths:
+        raise GitError("No paths provided to stage.")
+
+    repo_root = detect_git_root(paths[0])
+    relative_paths = [str(Path(path).resolve().relative_to(repo_root)) for path in paths]
+
+    try:
+        _run_git_command(["add", "--", *relative_paths], cwd=repo_root)
+    except subprocess.CalledProcessError as exc:
+        raise GitError(exc.stderr.strip() or "Failed to stage paths.") from exc
+
+    return "Staged: " + ", ".join(relative_paths)
+
+
+def open_in_editor(target_path: os.PathLike[str] | str) -> str:
+    """Open ``target_path`` in the user's ``$EDITOR``.
+
+    Returns a status message so callers can surface the action inside the UI.
+    """
+
+    editor = os.environ.get("EDITOR")
+    if not editor:
+        raise GitError("$EDITOR environment variable is not set.")
+
+    target = Path(target_path).resolve()
+    subprocess.run([editor, str(target)], check=True)
+    return f"Opened {target} in {editor}."


### PR DESCRIPTION
## Summary
- add a neurocli_core.git_tools module that resolves the repo root and wraps git status, apply, stage, and $EDITOR helpers
- update the Textual UI to surface git status, stage/apply actions, and editor launchers with run_worker feedback and non-repo fallbacks
- document the git-enabled workflow, prerequisites, and safeguards in the README

## Testing
- pytest *(fails: missing dotenv dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e0cccfd4832eb8b9bdd0357fd1b0