### PR TITLE
Reset active gate and clarify roadmap status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Use this file as a router. Current work belongs only in `handoff/active_gate/`; 
 | Need | Read |
 | --- | --- |
 | Start any project task | `handoff/active_gate/README.md` |
-| Understand the phased direction | `handoff/plans/roadmap.md` |
+| Review non-binding future options | `handoff/plans/roadmap.md` |
 | Change a backend or API contract | `handoff/coordination/shared_decisions.md` |
 | Compare Textual and React behavior | `handoff/coordination/frontend_parity.md` |
 | Review owner-specific work | `handoff/coordination/codex_handoff.md` or `handoff/coordination/gemini_handoff.md` |

--- a/handoff/README.md
+++ b/handoff/README.md
@@ -5,7 +5,7 @@
 | Need | Read |
 | --- | --- |
 | Work on the active goal | `active_gate/README.md` |
-| Understand product direction | `plans/roadmap.md` |
+| Review non-binding future options | `plans/roadmap.md` |
 | Use shared backend/API contracts | `coordination/shared_decisions.md` |
 | Compare Textual and React behavior | `coordination/frontend_parity.md` |
 | Confirm ownership boundaries | `coordination/codex_handoff.md` or `coordination/gemini_handoff.md` |

--- a/handoff/active_gate/README.md
+++ b/handoff/active_gate/README.md
@@ -1,56 +1,7 @@
-# Active Gate: Terminal-First Experience
+# Active Gate
 
-## Goal
+## Status
 
-Make the Textual application a clear, reliable developer cockpit for the complete safe workflow.
+Awaiting User Goal.
 
-## User Outcome
-
-A Textual user can choose a target and context, configure the model, run the workflow, inspect the timeline and diff, edit the proposal, validate it, apply it with a backup, inspect workspace radar, and prepare a commit without leaving the application.
-
-## Scope
-
-Improve focus order, keyboard flow, diff readability, review-editor ergonomics, validation readiness, timeline clarity, reset behavior, and explicit safe-workflow controls.
-
-Primary files:
-
-- `neurocli_app/main.py`
-- `neurocli_app/main.css`
-- `neurocli_app/review_modal.py`
-- `neurocli_app/command_modal.py`
-- `neurocli_app/workflow_adapter.py`
-- focused tests under `tests/`
-
-Use `neurocli_core` only when a change requires shared behavior. Do not place workflow business rules in Textual widgets.
-
-## Required Contracts
-
-- `handoff/coordination/shared_decisions.md`
-- `handoff/coordination/frontend_parity.md`
-- `handoff/plans/roadmap.md`
-
-## Acceptance
-
-The Textual workflow must expose target, context, model, run, review, validation, apply-with-backup, radar, and commit-readiness controls with discoverable keyboard navigation.
-
-No change may apply, commit, or push without explicit user action. Validation must use approved labels and reject unsafe targets without starting a process. Timeline metadata must remain concise and redacted.
-
-## Verification
-
-Run:
-
-`python -m unittest discover tests`
-
-`python -m ruff check neurocli_core api neurocli_app tests`
-
-Perform a manual Textual smoke test covering target selection, context, model settings, streaming, proposal review, validation, reset, apply readiness, radar, and Git readiness.
-
-Run the React checks if a shared contract or React integration changes:
-
-`npm --prefix web_client run lint`
-
-`npm --prefix web_client run build`
-
-## Owner
-
-Codex owns this gate. React presentation work begins only when this gate defines a bounded Gemini handoff. Control returns to the user for application-level acceptance after automated and manual verification.
+No implementation, planning, delegation, or contract change is authorized. The user will define the next work.

--- a/handoff/plans/roadmap.md
+++ b/handoff/plans/roadmap.md
@@ -1,5 +1,7 @@
 # NeuroCLI Roadmap
 
+> FUTURE OPTIONS ONLY: This roadmap is not active work, a schedule, or authorization to begin implementation. Current work is defined exclusively in `handoff/active_gate/README.md`.
+
 ## Product Direction
 
 NeuroCLI is a terminal-first AI development environment. The Textual app is the flagship surface. React is a supported companion surface over the same backend capability engine. The backend contract matters, but a phase is not product-complete until the docs say what a user can actually do in the application.


### PR DESCRIPTION
Clear the active gate to await new user direction and reframe the roadmap as non-binding future options, not an active schedule or authorization for implementation. Update navigation language across handoff docs to reflect that roadmap is exploratory only.